### PR TITLE
Fix: Game ends before the last note can be played

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,6 +9,7 @@ import { Loader2 } from 'lucide-react';
 const App: React.FC = () => {
   const [gameState, setGameState] = useState<GameState>(GameState.Ready);
   const [beatmap, setBeatmap] = useState<Beatmap | null>(null);
+  const [gameDuration, setGameDuration] = useState<number>(0);
   const [score, setScore] = useState<Score>({
     points: 0,
     combo: 0,
@@ -27,8 +28,15 @@ const App: React.FC = () => {
     setError(null);
     try {
       const newBeatmap = await generateBeatmap(prompt);
+      if (newBeatmap.length === 0) {
+        setError('Failed to generate beatmap. The generated map was empty. Please try a different prompt.');
+        setGameState(GameState.Ready);
+        return;
+      }
       // Sort notes by time to ensure proper gameplay
       newBeatmap.sort((a, b) => a.time - b.time);
+      const lastNoteTime = newBeatmap[newBeatmap.length - 1].time;
+      setGameDuration(lastNoteTime);
       setBeatmap(newBeatmap);
       setScore({
         points: 0,
@@ -83,7 +91,7 @@ const App: React.FC = () => {
         );
       case GameState.Playing:
         return beatmap ? (
-          <Game beatmap={beatmap} onGameFinish={handleGameFinish} />
+          <Game beatmap={beatmap} onGameFinish={handleGameFinish} gameDuration={gameDuration} />
         ) : null;
       case GameState.Finished:
         return <ResultsScreen score={score} onRestart={handleRestart} />;

--- a/components/Game.tsx
+++ b/components/Game.tsx
@@ -15,9 +15,10 @@ import { BarChart, Gauge } from 'lucide-react';
 interface GameProps {
   beatmap: Beatmap;
   onGameFinish: (finalScore: Score) => void;
+  gameDuration: number;
 }
 
-const Game: React.FC<GameProps> = ({ beatmap, onGameFinish }) => {
+const Game: React.FC<GameProps> = ({ beatmap, onGameFinish, gameDuration }) => {
   const [startTime, setStartTime] = useState<number>(0);
   const [currentTime, setCurrentTime] = useState<number>(0);
   const [notes, setNotes] = useState<NoteType[]>(beatmap);
@@ -123,7 +124,8 @@ const Game: React.FC<GameProps> = ({ beatmap, onGameFinish }) => {
   
   // This separate useEffect handles the finish condition to avoid stale score state in the game loop.
   useEffect(() => {
-    if (currentTime >= GAME_DURATION_MS + 2000) {
+    // Finish the game 2 seconds after the last note has passed the hit line
+    if (currentTime >= gameDuration + 2000) {
        if (gameLoopRef.current) cancelAnimationFrame(gameLoopRef.current);
        onGameFinish(score);
     }


### PR DESCRIPTION
The game was previously set to a fixed duration of 30 seconds. This caused an issue where, if the generated beatmap had notes appearing at or near the 30-second mark, the game would end before you had a chance to hit them.

This commit fixes the bug by dynamically setting the game's duration based on the timestamp of the last note in the generated beatmap. A 2-second buffer is added after the last note to ensure you have ample time to complete the game.

Changes:
- `App.tsx`: Calculates the time of the last note and passes it as a `gameDuration` prop to the `Game` component.
- `Game.tsx`: Uses the `gameDuration` prop to determine when to end the game, instead of a fixed constant.